### PR TITLE
Release `v1.0.32`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 `1.0.32`
 
 - Added `ExecutionWrapper` to `ReschedulingTask`.
-- Added `ExecutionWrappers` utility class which provide basic wrappers.
+- Added `ExecutionWrappers` utility class which provides basic wrappers.
 - Added `ExecutionWrappers.log` wrapper which logs a start and an end message for the executed task.
 - Added `ExecutionWrappers.time` which times and logs the execution time for the executed task.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 `1.0.32`
 
 - Added `ExecutionWrapper` to `ReschedulingTask`.
+- Added `ExecutionWrappers` utility class which provide basic wrappers.
+- Added `ExecutionWrappers.log` wrapper which logs a start and an end message for the executed task.
+- Added `ExecutionWrappers.time` which times and logs the execution time for the executed task.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+`1.0.32`
+
+- Added `ExecutionWrapper` to `ReschedulingTask`.
+
+---
+
 `1.0.31`
 
 - Changed all `ExecutorService` parameters in `Threads` class to `Executor` for better flexibility.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A library that exposes general Java utility and reflection methods and a package
 
 ### Releases
 
-Current release `1.0.31`
+Current release `1.0.32`
 
 ### Documentation
 
@@ -81,6 +81,6 @@ Maven: add this dependency to your `pom.xml`
 <dependency>
     <groupId>io.github.raduking</groupId>
     <artifactId>morphix-all</artifactId>
-    <version>1.0.31</version>
+    <version>1.0.32</version>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<groupId>io.github.raduking</groupId>
 	<artifactId>morphix-all</artifactId>
-	<version>1.0.31</version>
+	<version>1.0.32</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/org/morphix/convert/MapConversions.java
+++ b/src/main/java/org/morphix/convert/MapConversions.java
@@ -176,7 +176,7 @@ public interface MapConversions {
 	 */
 	static <S, H, D> MapConversionPipeline<String, Object, H, D> convert(final S source, final SimpleConverter<String, H> keyConverter,
 			final SimpleConverter<Object, D> valueConverter, final PutFunction<String, Object> putFunction) {
-		if (source == null) {
+		if (null == source) {
 			return convertMap(Map.of(), keyConverter, valueConverter);
 		}
 		List<ExtendedField> fields = ExtendedFields.findAllNonStatic(source);

--- a/src/main/java/org/morphix/convert/strategy/FinderPathStrategy.java
+++ b/src/main/java/org/morphix/convert/strategy/FinderPathStrategy.java
@@ -72,7 +72,7 @@ public class FinderPathStrategy implements FieldFinderStrategy {
 			} else {
 				resultObject = null;
 			}
-			if (resultField == null) {
+			if (null == resultField) {
 				break;
 			}
 		}

--- a/src/main/java/org/morphix/lang/Ids.java
+++ b/src/main/java/org/morphix/lang/Ids.java
@@ -276,7 +276,7 @@ public class Ids {
 	 * @return true if the string is a BigInteger, false otherwise
 	 */
 	public static boolean isBigInteger(final String str) {
-		if (str == null) {
+		if (null == str) {
 			return false;
 		}
 		int length = str.length();

--- a/src/main/java/org/morphix/lang/function/ExecutionWrapper.java
+++ b/src/main/java/org/morphix/lang/function/ExecutionWrapper.java
@@ -14,6 +14,8 @@ package org.morphix.lang.function;
 
 import java.util.function.Supplier;
 
+import org.morphix.lang.JavaObjects;
+
 /**
  * Functional interface representing a wrapper for executing code with additional behavior. This interface allows you to
  * wrap the execution of a supplier or a runnable with custom logic, such as logging, error handling, or performance
@@ -25,6 +27,12 @@ import java.util.function.Supplier;
  */
 @FunctionalInterface
 public interface ExecutionWrapper<T> {
+
+	/**
+	 * An empty wrapper that does not modify the behavior of the supplier. This wrapper simply returns the original supplier
+	 * without any additional behavior.
+	 */
+	ExecutionWrapper<?> EMPTY = supplier -> supplier;
 
 	/**
 	 * Wraps the execution of a supplier with additional behavior.
@@ -85,7 +93,7 @@ public interface ExecutionWrapper<T> {
 	 * @return an identity wrapper that does not modify the behavior of the supplier
 	 */
 	static <T> ExecutionWrapper<T> identity() {
-		return supplier -> supplier;
+		return JavaObjects.cast(EMPTY);
 	}
 
 	/**

--- a/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
+++ b/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
@@ -34,7 +34,7 @@ public final class ExecutionWrappers {
 
 	/**
 	 * Creates an {@link ExecutionWrapper} that logs the start and end of execution using the provided
-	 * {@link LoggerAdapter}. The logging level uses is {@link LoggingLevel#DEBUG} by default.
+	 * {@link LoggerAdapter}. The default logging level is {@link LoggingLevel#DEBUG}.
 	 *
 	 * @param logger the logger to use for logging execution events
 	 * @param name a name to identify the execution in the log messages

--- a/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
+++ b/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
@@ -12,6 +12,7 @@
  */
 package org.morphix.lang.function;
 
+import org.morphix.lang.function.LoggerAdapter.LoggingLevel;
 import org.morphix.reflection.Constructors;
 
 /**
@@ -33,7 +34,7 @@ public final class ExecutionWrappers {
 
 	/**
 	 * Creates an {@link ExecutionWrapper} that logs the start and end of execution using the provided
-	 * {@link LoggerAdapter}.
+	 * {@link LoggerAdapter}. The logging level uses is {@link LoggingLevel#DEBUG} by default.
 	 *
 	 * @param logger the logger to use for logging execution events
 	 * @param name a name to identify the execution in the log messages
@@ -41,9 +42,23 @@ public final class ExecutionWrappers {
 	 * @return an {@link ExecutionWrapper} that logs execution events
 	 */
 	public static <T> ExecutionWrapper<T> log(final LoggerAdapter logger, final String name) {
+		return log(logger, LoggingLevel.DEBUG, name);
+	}
+
+	/**
+	 * Creates an {@link ExecutionWrapper} that logs the start and end of execution using the provided {@link LoggerAdapter}
+	 * and logging level.
+	 *
+	 * @param logger the logger to use for logging execution events
+	 * @param level the logging level to use for logging execution events
+	 * @param name a name to identify the execution in the log messages
+	 * @param <T> the type of the result produced by the supplier
+	 * @return an {@link ExecutionWrapper} that logs execution events
+	 */
+	public static <T> ExecutionWrapper<T> log(final LoggerAdapter logger, final LoggingLevel level, final String name) {
 		return ExecutionWrapper.around(
-				() -> logger.debug("[{}] Starting execution.", name),
-				() -> logger.debug("[{}] Finished execution.", name));
+				() -> logger.log(level, "[{}] Starting execution.", name),
+				() -> logger.log(level, "[{}] Finished execution.", name));
 	}
 
 	/**

--- a/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
+++ b/src/main/java/org/morphix/lang/function/ExecutionWrappers.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.morphix.lang.function;
+
+import org.morphix.reflection.Constructors;
+
+/**
+ * Utility class providing common {@link ExecutionWrapper} implementations.
+ * <p>
+ * Example usage:
+ *
+ * <pre>{@code
+ * ExecutionWrapper<Void> loggingWrapper = ExecutionWrappers.log(logger, "refresh");
+ * ExecutionWrapper<Void> timingWrapper = ExecutionWrappers.time(logger, "refresh");
+ * ExecutionWrapper<Void> wrapper = loggingWrapper.andThen(timingWrapper);
+ *
+ * wrapper.execute(() -> refreshToken());
+ * }</pre>
+ *
+ * @author Radu Sebastian LAZIN
+ */
+public final class ExecutionWrappers {
+
+	/**
+	 * Creates an {@link ExecutionWrapper} that logs the start and end of execution using the provided
+	 * {@link LoggerAdapter}.
+	 *
+	 * @param logger the logger to use for logging execution events
+	 * @param name a name to identify the execution in the log messages
+	 * @param <T> the type of the result produced by the supplier
+	 * @return an {@link ExecutionWrapper} that logs execution events
+	 */
+	public static <T> ExecutionWrapper<T> log(final LoggerAdapter logger, final String name) {
+		return ExecutionWrapper.around(
+				() -> logger.debug("[{}] Starting execution.", name),
+				() -> logger.debug("[{}] Finished execution.", name));
+	}
+
+	/**
+	 * Creates an {@link ExecutionWrapper} that measures and logs the execution time of the wrapped supplier using the
+	 * provided {@link LoggerAdapter}.
+	 *
+	 * @param logger the logger to use for logging execution time
+	 * @param name a name to identify the execution in the log messages
+	 * @param <T> the type of the result produced by the supplier
+	 * @return an {@link ExecutionWrapper} that measures and logs execution time
+	 */
+	public static <T> ExecutionWrapper<T> time(final LoggerAdapter logger, final String name) {
+		return supplier -> () -> {
+			long start = System.nanoTime();
+			try {
+				return supplier.get();
+			} finally {
+				long duration = System.nanoTime() - start;
+				logger.debug("[{}] Execution took {}ms.", name, duration / 1_000_000);
+			}
+		};
+	}
+
+	/**
+	 * Private constructor to prevent instantiation of this utility class.
+	 */
+	private ExecutionWrappers() {
+		throw Constructors.unsupportedOperationException();
+	}
+}

--- a/src/main/java/org/morphix/lang/function/PutFunction.java
+++ b/src/main/java/org/morphix/lang/function/PutFunction.java
@@ -107,6 +107,6 @@ public interface PutFunction<K, V> {
 	 * @return put function
 	 */
 	static <K, V> PutFunction<K, V> ifNotNullKeyAndValue() {
-		return (map, key, value) -> (key != null && value != null) ? map.put(key, value) : null;
+		return (map, key, value) -> (null != key && null != value) ? map.put(key, value) : null;
 	}
 }

--- a/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
+++ b/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.morphix.lang.Comparables;
-import org.morphix.lang.JavaObjects;
 import org.morphix.lang.Nullables;
 import org.morphix.lang.function.ExecutionWrapper;
 import org.morphix.lang.function.LoggerAdapter;
@@ -386,8 +385,8 @@ public class ReschedulingTask implements AutoCloseable {
 	 *
 	 * @return the execution wrapper
 	 */
-	protected <T> ExecutionWrapper<T> getExecutionWrapper() {
-		return JavaObjects.cast(executionWrapper);
+	protected ExecutionWrapper<Void> getExecutionWrapper() {
+		return executionWrapper;
 	}
 
 	/**

--- a/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
+++ b/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
@@ -23,7 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.morphix.lang.Comparables;
+import org.morphix.lang.JavaObjects;
 import org.morphix.lang.Nullables;
+import org.morphix.lang.function.ExecutionWrapper;
 import org.morphix.lang.function.LoggerAdapter;
 import org.morphix.lang.resource.ScopedResource;
 import org.morphix.lang.retry.Retry;
@@ -52,7 +54,12 @@ import org.morphix.reflection.Constructors;
 public class ReschedulingTask implements AutoCloseable {
 
 	/**
-	 * Name space class for default values.
+	 * Name space class for default values. Other defaults which are not constants:
+	 * <ul>
+	 * <li>The logger defaults to {@link LoggerAdapter#none()}</li>
+	 * <li>The execution wrapper defaults to {@link ExecutionWrapper#identity()}</li>
+	 * <li>The task cancellation retry strategy defaults to {@link Retry#noRetry()}</li>
+	 * </ul>
 	 *
 	 * @author Radu Sebastian LAZIN
 	 */
@@ -95,6 +102,13 @@ public class ReschedulingTask implements AutoCloseable {
 	 * The task to be executed and rescheduled.
 	 */
 	private final Runnable refreshTask;
+
+	/**
+	 * The execution wrapper for the refresh task. This allows for additional behavior to be added around the execution of
+	 * the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
+	 * runs the task.
+	 */
+	private final ExecutionWrapper<?> executionWrapper;
 
 	/**
 	 * Supplier that provides the delay until the next execution after each run. The delay is recalculated after each
@@ -142,6 +156,7 @@ public class ReschedulingTask implements AutoCloseable {
 		this.refreshTask = Objects.requireNonNull(builder.refreshTask, "refreshTask must not be null");
 		this.nextDelaySupplier = Objects.requireNonNull(builder.nextDelaySupplier, "nextDelaySupplier must not be null");
 
+		this.executionWrapper = Nullables.nonNullOrDefault(builder.executionWrapper, ExecutionWrapper::identity);
 		this.logger = Nullables.nonNullOrDefault(builder.logger, LoggerAdapter::none);
 		this.minDelay = Nullables.nonNullOrDefault(builder.minDelay, () -> Default.MIN_DELAY);
 		if (minDelay.isNegative() || minDelay.isZero()) {
@@ -234,7 +249,11 @@ public class ReschedulingTask implements AutoCloseable {
 			return;
 		}
 		try {
-			refreshTask.run();
+			if (ExecutionWrapper.EMPTY != executionWrapper) {
+				executionWrapper.execute(refreshTask);
+			} else {
+				refreshTask.run();
+			}
 		} catch (Exception e) {
 			logger.error("[{}] Error during task execution.", name, e);
 		} finally {
@@ -362,6 +381,16 @@ public class ReschedulingTask implements AutoCloseable {
 	}
 
 	/**
+	 * Returns the execution wrapper for the refresh task. This allows for additional behavior to be added around the
+	 * execution of the refresh task, such as logging, error handling, metrics, etc.
+	 *
+	 * @return the execution wrapper
+	 */
+	protected <T> ExecutionWrapper<T> getExecutionWrapper() {
+		return JavaObjects.cast(executionWrapper);
+	}
+
+	/**
 	 * Returns the supplier that provides the delay until the next execution after each run.
 	 *
 	 * @return the next delay supplier
@@ -427,6 +456,13 @@ public class ReschedulingTask implements AutoCloseable {
 		 * The task to be executed and rescheduled. Must not be null.
 		 */
 		private Runnable refreshTask;
+
+		/**
+		 * The execution wrapper for the refresh task. This allows for additional behavior to be added around the execution of
+		 * the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
+		 * runs the task.
+		 */
+		private ExecutionWrapper<?> executionWrapper;
 
 		/**
 		 * Supplier that provides the delay until the next execution after each run. The delay is recalculated after each
@@ -503,6 +539,19 @@ public class ReschedulingTask implements AutoCloseable {
 		 */
 		public Builder task(final Runnable refreshTask) {
 			this.refreshTask = Objects.requireNonNull(refreshTask, "refreshTask must not be null");
+			return this;
+		}
+
+		/**
+		 * Sets the execution wrapper for the refresh task. This allows for additional behavior to be added around the execution
+		 * of the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
+		 * runs the task.
+		 *
+		 * @param executionWrapper the execution wrapper, optional, defaults to a simple wrapper that just runs the task
+		 * @return this builder for chaining
+		 */
+		public Builder executionWrapper(final ExecutionWrapper<?> executionWrapper) {
+			this.executionWrapper = executionWrapper;
 			return this;
 		}
 

--- a/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
+++ b/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
@@ -235,6 +235,7 @@ public class ReschedulingTask implements AutoCloseable {
 		if (isDone(task)) {
 			return true;
 		}
+		logger.debug("[{}] Attempting to cancel scheduled task: hashCode:[{}], state:[{}].", name, task.hashCode(), task.state());
 		return taskCancelRetry.until(() -> task.cancel(interruptOnCancel), Boolean::booleanValue);
 	}
 

--- a/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
+++ b/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
@@ -106,9 +106,9 @@ public class ReschedulingTask implements AutoCloseable {
 	/**
 	 * The execution wrapper for the refresh task. This allows for additional behavior to be added around the execution of
 	 * the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
-	 * runs the task.
+	 * runs the task. We use {@link Void} since the refresh task is a {@link Runnable} that does not produce a result.
 	 */
-	private final ExecutionWrapper<?> executionWrapper;
+	private final ExecutionWrapper<Void> executionWrapper;
 
 	/**
 	 * Supplier that provides the delay until the next execution after each run. The delay is recalculated after each
@@ -460,9 +460,9 @@ public class ReschedulingTask implements AutoCloseable {
 		/**
 		 * The execution wrapper for the refresh task. This allows for additional behavior to be added around the execution of
 		 * the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
-		 * runs the task.
+		 * runs the task. We use {@link Void} since the refresh task is a {@link Runnable} that does not produce a result.
 		 */
-		private ExecutionWrapper<?> executionWrapper;
+		private ExecutionWrapper<Void> executionWrapper;
 
 		/**
 		 * Supplier that provides the delay until the next execution after each run. The delay is recalculated after each
@@ -483,8 +483,8 @@ public class ReschedulingTask implements AutoCloseable {
 		private Retry taskCancelRetry;
 
 		/**
-		 * Whether to interrupt the task thread when cancelling. This is used in the cancellation logic when trying to cancel
-		 * the currently scheduled task before scheduling a new one. Optional, defaults to false (do not interrupt).
+		 * Whether to interrupt the task thread when canceling. This is used in the cancellation logic when trying to cancel the
+		 * currently scheduled task before scheduling a new one. Optional, defaults to false (do not interrupt).
 		 */
 		private boolean interruptOnCancel = Default.INTERRUPT_ON_CANCEL;
 
@@ -545,14 +545,24 @@ public class ReschedulingTask implements AutoCloseable {
 		/**
 		 * Sets the execution wrapper for the refresh task. This allows for additional behavior to be added around the execution
 		 * of the refresh task, such as logging, error handling, metrics, etc. Optional, defaults to a simple wrapper that just
-		 * runs the task.
+		 * runs the task. We use {@link Void} since the refresh task is a {@link Runnable} that does not produce a result.
 		 *
 		 * @param executionWrapper the execution wrapper, optional, defaults to a simple wrapper that just runs the task
 		 * @return this builder for chaining
 		 */
-		public Builder executionWrapper(final ExecutionWrapper<?> executionWrapper) {
+		public Builder executionWrapper(final ExecutionWrapper<Void> executionWrapper) {
 			this.executionWrapper = executionWrapper;
 			return this;
+		}
+
+		/**
+		 * Alias for {@link #executionWrapper(ExecutionWrapper)} for better readability when wrapping a runnable task.
+		 *
+		 * @param wrapper the execution wrapper, optional, defaults to a simple wrapper that just runs the task
+		 * @return this builder for chaining
+		 */
+		public Builder wrap(final ExecutionWrapper<Void> wrapper) {
+			return executionWrapper(wrapper);
 		}
 
 		/**

--- a/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
+++ b/src/main/java/org/morphix/lang/thread/ReschedulingTask.java
@@ -349,7 +349,7 @@ public class ReschedulingTask implements AutoCloseable {
 	 * @return true if the task is not scheduled, false if it is scheduled and not done
 	 */
 	public static boolean isDone(final ScheduledFuture<?> task) {
-		return task == null || task.isDone();
+		return null == task || task.isDone();
 	}
 
 	/**

--- a/src/main/java/org/morphix/reflection/Annotations.java
+++ b/src/main/java/org/morphix/reflection/Annotations.java
@@ -52,10 +52,10 @@ public class Annotations {
 	 *     {@code --add-opens} flags)
 	 */
 	public static <A extends Annotation> void overrideValue(final A annotation, final String attribute, final Object value) {
-		if (attribute == null || attribute.isBlank()) {
+		if (null == attribute || attribute.isBlank()) {
 			throw new IllegalArgumentException("Attribute name must be non-null and non-blank.");
 		}
-		if (annotation == null) {
+		if (null == annotation) {
 			throw new ReflectionException("Failed to override annotation: annotation instance is null (possibly not retained at runtime).");
 		}
 		try {

--- a/src/main/java/org/morphix/reflection/ExtendedField.java
+++ b/src/main/java/org/morphix/reflection/ExtendedField.java
@@ -383,7 +383,7 @@ public class ExtendedField {
 	 */
 	public <T extends Annotation> boolean isAnnotationPresent(final Class<T> annotation) {
 		boolean isPresent = false;
-		if (getterMethod != null) {
+		if (null != getterMethod) {
 			isPresent = getterMethod.isAnnotationPresent(annotation);
 		}
 		if (null != field) {

--- a/src/main/java/org/morphix/reflection/Fields.java
+++ b/src/main/java/org/morphix/reflection/Fields.java
@@ -537,7 +537,7 @@ public interface Fields {
 					} catch (ReflectionException e) {
 						value = null;
 					}
-					if (value == null) {
+					if (null == value) {
 						break;
 					}
 				}

--- a/src/main/java/org/morphix/reflection/GenericType.java
+++ b/src/main/java/org/morphix/reflection/GenericType.java
@@ -323,7 +323,7 @@ public class GenericType implements ParameterizedType {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 
-		if (ownerType != null) {
+		if (null != ownerType) {
 			sb.append(ownerType.getTypeName());
 			sb.append("$");
 			if (ownerType instanceof ParameterizedType ot) {

--- a/src/main/java/org/morphix/reflection/MethodType.java
+++ b/src/main/java/org/morphix/reflection/MethodType.java
@@ -233,7 +233,7 @@ public enum MethodType {
 	 * @return a field name based on a prefix and a method name
 	 */
 	public static String getFieldName(final String prefix, final String methodName) {
-		if (prefix == null || methodName == null || !startsWithStrict(prefix, methodName)) {
+		if (null == prefix || null == methodName || !startsWithStrict(prefix, methodName)) {
 			return null;
 		}
 		int index = prefix.length();

--- a/src/main/java/org/morphix/reflection/Methods.java
+++ b/src/main/java/org/morphix/reflection/Methods.java
@@ -666,7 +666,7 @@ public interface Methods {
 		 */
 		static <T> List<Method> getAllDeclaredInHierarchy(final Class<T> cls, final Set<Class<?>> excluded) {
 			try {
-				if (cls == null || excluded.contains(cls)) {
+				if (null == cls || excluded.contains(cls)) {
 					return new LinkedList<>();
 				}
 				excluded.add(cls);

--- a/src/main/java/org/morphix/reflection/jvm/InstanceCreatorOracleJDK.java
+++ b/src/main/java/org/morphix/reflection/jvm/InstanceCreatorOracleJDK.java
@@ -47,7 +47,7 @@ public class InstanceCreatorOracleJDK extends InstanceCreator { // NOSONAR
 	 */
 	@Override
 	public boolean isUsable() {
-		return newConstructorForSerializationMethod != null;
+		return null != newConstructorForSerializationMethod;
 	}
 
 	/**

--- a/src/test/java/org/morphix/benchmark/NullablesOptional.java
+++ b/src/test/java/org/morphix/benchmark/NullablesOptional.java
@@ -89,7 +89,7 @@ public class NullablesOptional {
 
 	@Benchmark
 	public List<String> testTernary() {
-		return hotel.images() != null ? hotel.images().names() : null;
+		return null != hotel.images() ? hotel.images().names() : null;
 	}
 
 	@Benchmark

--- a/src/test/java/org/morphix/convert/CloneOfTest.java
+++ b/src/test/java/org/morphix/convert/CloneOfTest.java
@@ -56,7 +56,7 @@ class CloneOfTest {
 
 		public void setTemporaryD(final D temporaryD) {
 			this.temporaryD = temporaryD;
-			if (temporaryD.getParentD() == null) {
+			if (null == temporaryD.getParentD()) {
 				this.temporaryD.setParentD(this);
 			}
 		}

--- a/src/test/java/org/morphix/convert/FromIterableTest.java
+++ b/src/test/java/org/morphix/convert/FromIterableTest.java
@@ -53,7 +53,7 @@ class FromIterableTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 
@@ -73,7 +73,7 @@ class FromIterableTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 

--- a/src/test/java/org/morphix/convert/MapConversionsConvertMapTest.java
+++ b/src/test/java/org/morphix/convert/MapConversionsConvertMapTest.java
@@ -67,7 +67,7 @@ class MapConversionsConvertMapTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 
@@ -88,7 +88,7 @@ class MapConversionsConvertMapTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 

--- a/src/test/java/org/morphix/convert/handler/IterableToIterableInstancesTest.java
+++ b/src/test/java/org/morphix/convert/handler/IterableToIterableInstancesTest.java
@@ -251,7 +251,7 @@ class IterableToIterableInstancesTest {
 		List<Integer> a;
 
 		public List<Integer> getA() {
-			return a == null ? emptyList() : a;
+			return null == a ? emptyList() : a;
 		}
 	}
 

--- a/src/test/java/org/morphix/convert/handler/MapToMapTest.java
+++ b/src/test/java/org/morphix/convert/handler/MapToMapTest.java
@@ -73,7 +73,7 @@ class MapToMapTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 
@@ -93,7 +93,7 @@ class MapToMapTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 
@@ -276,7 +276,7 @@ class MapToMapTest {
 		Map<String, String> a;
 
 		public Map<String, String> getA() {
-			return a == null ? emptyMap() : a;
+			return null == a ? emptyMap() : a;
 		}
 	}
 

--- a/src/test/java/org/morphix/convert/handler/MapToMapWithExpandableTest.java
+++ b/src/test/java/org/morphix/convert/handler/MapToMapWithExpandableTest.java
@@ -61,7 +61,7 @@ class MapToMapWithExpandableTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 
@@ -81,7 +81,7 @@ class MapToMapWithExpandableTest {
 
 		@Override
 		public int hashCode() {
-			return s == null ? super.hashCode() : s.hashCode();
+			return null == s ? super.hashCode() : s.hashCode();
 		}
 	}
 

--- a/src/test/java/org/morphix/lang/NullablesTest.java
+++ b/src/test/java/org/morphix/lang/NullablesTest.java
@@ -367,7 +367,7 @@ class NullablesTest {
 		String result = Nullables.whenNotNull(a)
 				.andNotNull(A::getB)
 				.andNotNull(B::getS)
-				.valueWhenOrDefault(s -> s == null, BIBI);
+				.valueWhenOrDefault(s -> null == s, BIBI);
 
 		assertThat(result, equalTo(BIBI));
 	}
@@ -693,7 +693,7 @@ class NullablesTest {
 	}
 
 	private static boolean isNotBlank(final String s) {
-		return s != null && !s.isBlank();
+		return null != s && !s.isBlank();
 	}
 
 }

--- a/src/test/java/org/morphix/lang/cache/ConcurrentStrictLRUCacheTest.java
+++ b/src/test/java/org/morphix/lang/cache/ConcurrentStrictLRUCacheTest.java
@@ -127,26 +127,26 @@ class ConcurrentStrictLRUCacheTest extends StrictLRUCacheTest {
 			Node<K, V> tail = cc.tail();
 
 			// head/tail consistency
-			if (head == null || tail == null) {
+			if (null == head || null == tail) {
 				if (head != tail) {
-					throw new IllegalStateException("Head/tail mismatch: one null, one not");
+					throw new IllegalStateException("Found head/tail mismatch: one null, one not");
 				}
 				if (cc.size() != 0) {
 					throw new IllegalStateException("Size not zero but list empty");
 				}
 				return;
 			}
-			if (head.prev() != null) {
-				throw new IllegalStateException("Head.prev != null");
+			if (null != head.prev()) {
+				throw new IllegalStateException("Found: null != head.prev");
 			}
-			if (tail.next() != null) {
-				throw new IllegalStateException("Tail.next != null");
+			if (null != tail.next()) {
+				throw new IllegalStateException("Found: null != tail.next");
 			}
 
 			// cycle detection
 			Node<K, V> slow = cc.head();
 			Node<K, V> fast = cc.head().next();
-			while (fast != null && fast.next() != null) {
+			while (null != fast && null != fast.next()) {
 				slow = slow.next();
 				fast = fast.next();
 				if (slow == fast) {
@@ -162,7 +162,7 @@ class ConcurrentStrictLRUCacheTest extends StrictLRUCacheTest {
 			int count = 0;
 			Node<K, V> prev = null;
 			Node<K, V> node = head;
-			while (node != null) {
+			while (null != node) {
 				if (node.prev() != prev) {
 					throw new IllegalStateException("Broken prev pointer at key=" + node.key());
 				}

--- a/src/test/java/org/morphix/lang/cache/StrictLRUCacheTest.java
+++ b/src/test/java/org/morphix/lang/cache/StrictLRUCacheTest.java
@@ -510,7 +510,7 @@ class StrictLRUCacheTest extends LRUCacheTest {
 		Set<Node<String, String>> visited = new HashSet<>();
 		StringBuilder sb = new StringBuilder();
 		Node<String, String> current = head;
-		while (current != null) {
+		while (null != current) {
 			if (!visited.add(current)) {
 				throw new IllegalStateException("Cycle detected in the linked list");
 			}

--- a/src/test/java/org/morphix/lang/function/ExecutionWrappersTest.java
+++ b/src/test/java/org/morphix/lang/function/ExecutionWrappersTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.morphix.lang.function;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.morphix.lang.function.LoggerAdapter.LoggingLevel;
+import org.morphix.lang.thread.Threads;
+import org.morphix.reflection.Constructors;
+import org.morphix.utils.Tests;
+import org.morphix.utils.logging.TestLoggerAdapter;
+
+/**
+ * Test class for {@link ExecutionWrappers}.
+ *
+ * @author Radu Sebastian LAZIN
+ */
+class ExecutionWrappersTest {
+
+	private static final String TEST_TASK = "TestTask";
+
+	@Test
+	void shouldThrowExceptionWhenTryingToInstantiate() {
+		UnsupportedOperationException e = Tests.verifyDefaultConstructorThrows(ExecutionWrappers.class);
+
+		assertThat(e.getMessage(), equalTo(Constructors.MESSAGE_THIS_CLASS_SHOULD_NOT_BE_INSTANTIATED));
+	}
+
+	@Test
+	void shouldLogStartAndFinishWhenUsingLogWrapper() {
+		TestLoggerAdapter logger = new TestLoggerAdapter();
+		ExecutionWrapper<String> wrapper = ExecutionWrappers.log(logger, TEST_TASK);
+
+		String result = wrapper.execute(() -> "done");
+
+		assertThat(result, is("done"));
+		assertThat(logger.getMessages(LoggingLevel.DEBUG), hasSize(2));
+		assertThat(logger.getMessages(LoggingLevel.DEBUG).get(0), is("[" + TEST_TASK + "] Starting execution."));
+		assertThat(logger.getMessages(LoggingLevel.DEBUG).get(1), is("[" + TEST_TASK + "] Finished execution."));
+	}
+
+	@Test
+	void shouldLogExecutionTimeWhenUsingTimeWrapper() {
+		TestLoggerAdapter logger = new TestLoggerAdapter();
+		ExecutionWrapper<String> wrapper = ExecutionWrappers.time(logger, TEST_TASK);
+
+		String result = wrapper.execute(() -> {
+			Threads.safeSleep(Duration.ofMillis(10));
+			return "done";
+		});
+
+		assertThat(result, is("done"));
+		assertThat(logger.getMessages(LoggingLevel.DEBUG), hasSize(1));
+		assertThat(logger.getMessages(LoggingLevel.DEBUG).get(0), containsString("[" + TEST_TASK + "] Execution took"));
+
+		// ensure a non-negative duration is logged
+		String message = logger.getMessages(LoggingLevel.DEBUG).get(0);
+		long duration = extractDurationMillis(message);
+
+		assertThat(duration, greaterThanOrEqualTo(0L));
+	}
+
+	/**
+	 * Extracts the duration in milliseconds from the log message.
+	 */
+	private static long extractDurationMillis(final String message) {
+		// Expected format: "[name] Execution took Xms."
+		int start = message.lastIndexOf("took ") + 5;
+		int end = message.lastIndexOf("ms");
+		return Long.parseLong(message.substring(start, end).trim());
+	}
+}

--- a/src/test/java/org/morphix/lang/function/ExecutionWrappersTest.java
+++ b/src/test/java/org/morphix/lang/function/ExecutionWrappersTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.Matchers.hasSize;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.morphix.lang.function.LoggerAdapter.LoggingLevel;
 import org.morphix.lang.thread.Threads;
 import org.morphix.reflection.Constructors;
@@ -45,7 +47,7 @@ class ExecutionWrappersTest {
 	}
 
 	@Test
-	void shouldLogStartAndFinishWhenUsingLogWrapper() {
+	void shouldLogStartAndFinishWhenUsingLogWrapperWithDefaultLevel() {
 		TestLoggerAdapter logger = new TestLoggerAdapter();
 		ExecutionWrapper<String> wrapper = ExecutionWrappers.log(logger, TEST_TASK);
 
@@ -55,6 +57,20 @@ class ExecutionWrappersTest {
 		assertThat(logger.getMessages(LoggingLevel.DEBUG), hasSize(2));
 		assertThat(logger.getMessages(LoggingLevel.DEBUG).get(0), is("[" + TEST_TASK + "] Starting execution."));
 		assertThat(logger.getMessages(LoggingLevel.DEBUG).get(1), is("[" + TEST_TASK + "] Finished execution."));
+	}
+
+	@ParameterizedTest
+	@EnumSource(LoggingLevel.class)
+	void shouldLogStartAndFinishWhenUsingLogWrapper(final LoggingLevel level) {
+		TestLoggerAdapter logger = new TestLoggerAdapter();
+		ExecutionWrapper<String> wrapper = ExecutionWrappers.log(logger, level, TEST_TASK);
+
+		String result = wrapper.execute(() -> "done");
+
+		assertThat(result, is("done"));
+		assertThat(logger.getMessages(level), hasSize(2));
+		assertThat(logger.getMessages(level).get(0), is("[" + TEST_TASK + "] Starting execution."));
+		assertThat(logger.getMessages(level).get(1), is("[" + TEST_TASK + "] Finished execution."));
 	}
 
 	@Test

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -39,12 +39,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.morphix.lang.function.ExecutionWrapper;
 import org.morphix.lang.function.LoggerAdapter;
 import org.morphix.lang.function.Runnables;
 import org.morphix.lang.resource.ScopedResource;
@@ -112,6 +114,7 @@ class ReschedulingTaskTest {
 			assertThat(task.getMinDelay(), is(ReschedulingTask.Default.MIN_DELAY));
 			assertThat(task.getLogger(), is(LoggerAdapter.none()));
 			assertThat(task.isInterruptOnCancel(), is(ReschedulingTask.Default.INTERRUPT_ON_CANCEL));
+			assertThat(task.getExecutionWrapper(), is(ExecutionWrapper.EMPTY));
 		}
 	}
 
@@ -938,6 +941,65 @@ class ReschedulingTaskTest {
 			boolean isNotDone = ReschedulingTask.isNotDone(null);
 
 			assertThat(isNotDone, is(false));
+		}
+	}
+
+	@Nested
+	class ExecutionWrapperTests {
+
+		@Test
+		@SuppressWarnings("resource")
+		void shouldExecuteTaskAndHandleExceptions() throws InterruptedException {
+			int executionCount = 3;
+
+			AtomicInteger wrapperCounter = new AtomicInteger();
+			AtomicInteger executionCounter = new AtomicInteger();
+
+			CountDownLatch latch = new CountDownLatch(3);
+			CountDownLatch disableLatch = new CountDownLatch(1);
+
+			ReschedulingTask task = ReschedulingTask.builder()
+					.name(TASK_NAME)
+					.scheduler(scheduler())
+					.task(() -> {
+						int executions = executionCounter.incrementAndGet();
+						LOGGER.info("Executing task, execution count: {}", executions);
+						latch.countDown();
+						if (executions == executionCount) {
+							Threads.safeWait(disableLatch);
+						}
+					})
+					.executionWrapper(wrapped -> () -> transaction("test-transaction", wrapped, wrapperCounter))
+					.nextDelay(() -> Duration.ofMillis(10))
+					.minDelay(Duration.ofMillis(10))
+					.logger(LOGGER)
+					.build();
+			task.enable();
+
+			Thread.ofVirtual().start(() -> {
+				Threads.safeWait(latch);
+				task.disable();
+				disableLatch.countDown();
+			});
+
+			boolean executed = latch.await(5, TimeUnit.SECONDS);
+
+			assertThat(executed, is(true));
+			assertThat(executionCounter.get(), is(wrapperCounter.get()));
+			assertThat(executionCounter.get(), is(executionCount));
+		}
+
+		private static <T> T transaction(final String name, final Supplier<T> supplier, final AtomicInteger counter) {
+			counter.incrementAndGet();
+			try {
+				LOGGER.info("Starting transaction '{}'", name);
+				T result = supplier.get();
+				LOGGER.info("Transaction '{}' completed successfully", name);
+				return result;
+			} catch (Exception e) {
+				LOGGER.error("Transaction '{}' failed", name, e);
+				throw e;
+			}
 		}
 	}
 }

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -849,6 +849,7 @@ class ReschedulingTaskTest {
 			doAnswer(invocation -> {
 				ScheduledFuture<?> scheduledFuture = (ScheduledFuture<?>) invocation.callRealMethod();
 				scheduledFuture = spy(scheduledFuture);
+				doReturn(false).when(scheduledFuture).isDone();
 				scheduledFutures.add(scheduledFuture);
 				return scheduledFuture;
 			}).when(scheduledExecutor).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
@@ -859,9 +860,9 @@ class ReschedulingTaskTest {
 					.name(TASK_NAME)
 					.scheduler(resource)
 					.task(() -> {
-						int count = counter.incrementAndGet();
+						counter.incrementAndGet();
 						latch.countDown();
-						if (count == executionCount) {
+						if (latch.getCount() == 0) {
 							Threads.safeWait(disableLatch);
 						}
 					})
@@ -871,16 +872,16 @@ class ReschedulingTaskTest {
 					.build();
 			task.enable();
 
-			Thread.ofVirtual().start(() -> {
+			Thread.ofVirtual().name("disable-task").start(() -> {
 				Threads.safeWait(latch);
 				task.disable();
 				disableLatch.countDown();
 			});
 
-			boolean completed = disableLatch.await(2, TimeUnit.SECONDS);
+			boolean completed = disableLatch.await(5, TimeUnit.SECONDS);
 
 			for (ScheduledFuture<?> scheduledFuture : scheduledFutures) {
-				verify(scheduledFuture, times(1)).cancel(anyBoolean());
+				verify(scheduledFuture).cancel(anyBoolean());
 			}
 			assertThat(completed, is(true));
 			assertThat(counter.get(), equalTo(executionCount));

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -84,7 +84,7 @@ class ReschedulingTaskTest {
 
 	@AfterEach
 	void tearDown() {
-		if (executor != null) {
+		if (null != executor) {
 			executor.shutdownNow();
 		}
 	}

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -957,7 +957,7 @@ class ReschedulingTaskTest {
 			AtomicInteger wrapperCounter = new AtomicInteger();
 			AtomicInteger executionCounter = new AtomicInteger();
 
-			CountDownLatch latch = new CountDownLatch(3);
+			CountDownLatch latch = new CountDownLatch(executionCount);
 			CountDownLatch disableLatch = new CountDownLatch(1);
 
 			ReschedulingTask task = ReschedulingTask.builder()
@@ -1027,10 +1027,11 @@ class ReschedulingTaskTest {
 					.build();
 			task.enable();
 
-			latch.await(1, TimeUnit.SECONDS);
+			boolean executed = latch.await(1, TimeUnit.SECONDS);
 
 			task.disable();
 
+			assertThat(executed, is(true));
 			verify(logger).debug("[{}] Enabling rescheduling task.", TASK_NAME);
 			verify(logger, atLeast(executionCount - 1)).debug("[{}] Scheduling next execution in {}ms.", TASK_NAME, DELAY.toMillis());
 			verify(logger).debug("[{}] Disabling rescheduling task.", TASK_NAME);

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -1010,7 +1010,7 @@ class ReschedulingTaskTest {
 		@Test
 		@SuppressWarnings("resource")
 		void shouldEnableAndDisableTaskAndLogExecution() throws InterruptedException {
-			int executionCount = 2;
+			int executionCount = 3;
 
 			CountDownLatch latch = new CountDownLatch(executionCount);
 
@@ -1031,7 +1031,7 @@ class ReschedulingTaskTest {
 			task.disable();
 
 			verify(logger).debug("[{}] Enabling rescheduling task.", TASK_NAME);
-			verify(logger, atLeast(executionCount)).debug("[{}] Scheduling next execution in {}ms.", TASK_NAME, DELAY.toMillis());
+			verify(logger, atLeast(executionCount - 1)).debug("[{}] Scheduling next execution in {}ms.", TASK_NAME, DELAY.toMillis());
 			verify(logger).debug("[{}] Disabling rescheduling task.", TASK_NAME);
 		}
 

--- a/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
+++ b/src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -54,8 +55,8 @@ import org.morphix.lang.retry.Retry;
 import org.morphix.lang.retry.WaitCounter;
 import org.morphix.reflection.Constructors;
 import org.morphix.reflection.Methods;
-import org.morphix.utils.JulLoggerAdapter;
 import org.morphix.utils.Tests;
+import org.morphix.utils.logging.JulLoggerAdapter;
 
 /**
  * Test class for {@link ReschedulingTask}.
@@ -969,7 +970,7 @@ class ReschedulingTaskTest {
 							Threads.safeWait(disableLatch);
 						}
 					})
-					.executionWrapper(wrapped -> () -> transaction("test-transaction", wrapped, wrapperCounter))
+					.wrap(wrapped -> () -> transaction("test-transaction", wrapped, wrapperCounter))
 					.nextDelay(() -> Duration.ofMillis(10))
 					.minDelay(Duration.ofMillis(10))
 					.logger(LOGGER)
@@ -1001,5 +1002,38 @@ class ReschedulingTaskTest {
 				throw e;
 			}
 		}
+	}
+
+	@Nested
+	class LoggingTests {
+
+		@Test
+		@SuppressWarnings("resource")
+		void shouldEnableAndDisableTaskAndLogExecution() throws InterruptedException {
+			int executionCount = 2;
+
+			CountDownLatch latch = new CountDownLatch(executionCount);
+
+			LoggerAdapter logger = mock(LoggerAdapter.class);
+
+			ReschedulingTask task = ReschedulingTask.builder()
+					.name(TASK_NAME)
+					.scheduler(scheduler())
+					.task(latch::countDown)
+					.nextDelay(() -> DELAY)
+					.minDelay(Duration.ofMillis(10))
+					.logger(logger)
+					.build();
+			task.enable();
+
+			latch.await(1, TimeUnit.SECONDS);
+
+			task.disable();
+
+			verify(logger).debug("[{}] Enabling rescheduling task.", TASK_NAME);
+			verify(logger, atLeast(executionCount)).debug("[{}] Scheduling next execution in {}ms.", TASK_NAME, DELAY.toMillis());
+			verify(logger).debug("[{}] Disabling rescheduling task.", TASK_NAME);
+		}
+
 	}
 }

--- a/src/test/java/org/morphix/reflection/InstanceCreatorTest.java
+++ b/src/test/java/org/morphix/reflection/InstanceCreatorTest.java
@@ -34,7 +34,7 @@ class InstanceCreatorTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		assumeTrue(InstanceCreator.getInstance() != null);
+		assumeTrue(null != InstanceCreator.getInstance());
 	}
 
 	@Test

--- a/src/test/java/org/morphix/utils/JulLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/JulLoggerAdapter.java
@@ -34,8 +34,26 @@ public final class JulLoggerAdapter implements LoggerAdapter {
 		if (!logger.isLoggable(julLevel)) {
 			return;
 		}
-		// TODO: log exceptions (if the last argument is a Throwable, log it as an exception)
-		logger.log(julLevel, format(message, args));
+		if (args == null || args.length == 0) {
+            logger.log(julLevel, message);
+            return;
+        }
+		final Object lastArg = args[args.length - 1];
+		if (lastArg instanceof Throwable throwable) {
+			String formattedMessage;
+			if (args.length == 1) {
+				// only exception was passed as argument, use the message as is
+				formattedMessage = message;
+			} else {
+				Object[] messageArgs = new Object[args.length - 1];
+				System.arraycopy(args, 0, messageArgs, 0, args.length - 1);
+				formattedMessage = Messages.message(message, messageArgs);
+			}
+			logger.log(julLevel, formattedMessage, throwable);
+		} else {
+			String formattedMessage = Messages.message(message, args);
+			logger.log(julLevel, formattedMessage);
+		}
 	}
 
 	private static Level toJulLevel(final LoggerAdapter.LoggingLevel level) {
@@ -46,12 +64,5 @@ public final class JulLoggerAdapter implements LoggerAdapter {
 			case WARN -> Level.WARNING;
 			case ERROR -> Level.SEVERE;
 		};
-	}
-
-	private static String format(final String message, final Object... args) {
-		if (args == null || args.length == 0) {
-			return message;
-		}
-		return Messages.message(message, args);
 	}
 }

--- a/src/test/java/org/morphix/utils/OneLineFormatter.java
+++ b/src/test/java/org/morphix/utils/OneLineFormatter.java
@@ -14,6 +14,8 @@ package org.morphix.utils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 
@@ -41,6 +43,8 @@ import org.morphix.lang.Messages;
  * @author Radu Sebastian LAZIN
  */
 public class OneLineFormatter extends Formatter {
+
+	private static final String INDENT = "  ";
 
 	/**
 	 * Date pattern for the timestamp.
@@ -94,6 +98,67 @@ public class OneLineFormatter extends Formatter {
 		// important! newline at the end of the log record
 		sb.append("\n");
 
+		// exception handling
+		Throwable thrown = logRecord.getThrown();
+		if (thrown != null) {
+			appendException(sb, thrown, INDENT);
+		}
+
 		return sb.toString();
+	}
+
+	/**
+	 * Appends exception in classic SLF4J / Logback style.
+	 *
+	 * @param sb the StringBuilder to append to
+	 * @param throwable the exception to append
+	 * @param indent the current indentation level (used for nested exceptions)
+	 */
+	private static void appendException(final StringBuilder sb, final Throwable throwable, final String indent) {
+		if (null == throwable) {
+			return;
+		}
+		appendException(sb, throwable, indent, new HashSet<>());
+	}
+
+	/**
+	 * Appends exception in classic SLF4J / Logback style, with circular reference detection.
+	 *
+	 * @param sb the StringBuilder to append to
+	 * @param throwable the exception to append
+	 * @param indent the current indentation level (used for nested exceptions)
+	 * @param visited the set of already visited exceptions to detect circular references
+	 */
+	private static void appendException(final StringBuilder sb, final Throwable throwable, final String indent, final Set<Throwable> visited) {
+		if (null == throwable) {
+			return;
+		}
+		if (!visited.add(throwable)) {
+			sb.append("[CIRCULAR REFERENCE]\n");
+			return;
+		}
+		sb.append(throwable.getClass().getName());
+
+		String msg = throwable.getMessage();
+		if (msg != null) {
+			sb.append(": ").append(msg);
+		}
+		sb.append("\n");
+
+		for (StackTraceElement element : throwable.getStackTrace()) {
+			sb.append(indent)
+					.append("at ")
+					.append(element)
+					.append("\n");
+		}
+		for (Throwable suppressed : throwable.getSuppressed()) {
+			sb.append(indent).append("Suppressed: ");
+			appendException(sb, suppressed, indent, visited);
+		}
+		Throwable cause = throwable.getCause();
+		if (cause != null) {
+			sb.append("Caused by: ");
+			appendException(sb, cause, indent, visited);
+		}
 	}
 }

--- a/src/test/java/org/morphix/utils/lang/thread/TenantContextHolder.java
+++ b/src/test/java/org/morphix/utils/lang/thread/TenantContextHolder.java
@@ -157,7 +157,7 @@ public class TenantContextHolder extends StackedContextHolder<String> {
 	 * @return true if the tenant ID is valid, false otherwise
 	 */
 	private static boolean isValidTenantId(final String tenantId) {
-		return tenantId != null && !tenantId.isBlank();
+		return null != tenantId && !tenantId.isBlank();
 	}
 
 	/**

--- a/src/test/java/org/morphix/utils/logging/JulLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/logging/JulLoggerAdapter.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.morphix.lang.JavaArrays;
 import org.morphix.lang.Messages;
 import org.morphix.lang.function.LoggerAdapter;
 
@@ -34,7 +35,7 @@ public final class JulLoggerAdapter implements LoggerAdapter {
 		if (!logger.isLoggable(julLevel)) {
 			return;
 		}
-		if (args == null || args.length == 0) {
+		if (JavaArrays.isEmpty(args)) {
 			logger.log(julLevel, message);
 			return;
 		}

--- a/src/test/java/org/morphix/utils/logging/JulLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/logging/JulLoggerAdapter.java
@@ -1,4 +1,4 @@
-package org.morphix.utils;
+package org.morphix.utils.logging;
 
 import java.util.Objects;
 import java.util.logging.Level;
@@ -35,9 +35,9 @@ public final class JulLoggerAdapter implements LoggerAdapter {
 			return;
 		}
 		if (args == null || args.length == 0) {
-            logger.log(julLevel, message);
-            return;
-        }
+			logger.log(julLevel, message);
+			return;
+		}
 		final Object lastArg = args[args.length - 1];
 		if (lastArg instanceof Throwable throwable) {
 			String formattedMessage;

--- a/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
+++ b/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 
+import org.morphix.lang.JavaArrays;
 import org.morphix.lang.Messages;
 
 /**
@@ -78,7 +79,7 @@ public class OneLineFormatter extends Formatter {
 
 		// logger name, only the class name (strip the package name)
 		String loggerName = logRecord.getLoggerName();
-		if (loggerName != null) {
+		if (null != loggerName) {
 			int lastDot = loggerName.lastIndexOf('.');
 			if (lastDot > 0) {
 				loggerName = loggerName.substring(lastDot + 1);
@@ -90,7 +91,7 @@ public class OneLineFormatter extends Formatter {
 		// message (replace SLF4J style {} with actual values)
 		String message = logRecord.getMessage();
 		Object[] params = logRecord.getParameters();
-		if (params != null && params.length > 0) {
+		if (JavaArrays.isNotEmpty(params)) {
 			message = Messages.message(message, params);
 		}
 		sb.append(message);
@@ -100,7 +101,7 @@ public class OneLineFormatter extends Formatter {
 
 		// exception handling
 		Throwable thrown = logRecord.getThrown();
-		if (thrown != null) {
+		if (null != thrown) {
 			appendException(sb, thrown, INDENT);
 		}
 
@@ -140,7 +141,7 @@ public class OneLineFormatter extends Formatter {
 		sb.append(throwable.getClass().getName());
 
 		String msg = throwable.getMessage();
-		if (msg != null) {
+		if (null != msg) {
 			sb.append(": ").append(msg);
 		}
 		sb.append("\n");
@@ -156,7 +157,7 @@ public class OneLineFormatter extends Formatter {
 			appendException(sb, suppressed, indent, visited);
 		}
 		Throwable cause = throwable.getCause();
-		if (cause != null) {
+		if (null != cause) {
 			sb.append("Caused by: ");
 			appendException(sb, cause, indent, visited);
 		}

--- a/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
+++ b/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.morphix.utils;
+package org.morphix.utils.logging;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
+++ b/src/test/java/org/morphix/utils/logging/OneLineFormatter.java
@@ -32,7 +32,7 @@ import org.morphix.lang.Messages;
  * to this class:
  *
  * <pre>
- * java.util.logging.ConsoleHandler.formatter = org.morphix.utils.OneLineFormatter
+ * java.util.logging.ConsoleHandler.formatter = org.morphix.utils.logging.OneLineFormatter
  * </pre>
  *
  * The file can be configured to be used by the JVM with the following system property:

--- a/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
@@ -31,14 +31,14 @@ public final class TestLoggerAdapter implements LoggerAdapter {
 	 * Map that stores log messages categorized by their logging level. Each logging level maps to a list of messages logged
 	 * at that level.
 	 */
-	private final Map<LoggingLevel, List<String>> debugMessages = new EnumMap<>(LoggingLevel.class);
+	private final Map<LoggingLevel, List<String>> messages = new EnumMap<>(LoggingLevel.class);
 
 	/**
 	 * @see LoggerAdapter#log(LoggingLevel, String, Object...)
 	 */
 	@Override
 	public void log(final LoggingLevel level, final String message, final Object... args) {
-		debugMessages.computeIfAbsent(level, k -> new ArrayList<>()).add(Messages.message(message, args));
+		messages.computeIfAbsent(level, k -> new ArrayList<>()).add(Messages.message(message, args));
 	}
 
 	/**
@@ -48,7 +48,7 @@ public final class TestLoggerAdapter implements LoggerAdapter {
 	 * @return the map of logged messages categorized by logging level
 	 */
 	public Map<LoggingLevel, List<String>> getMessages() {
-		return debugMessages;
+		return messages;
 	}
 
 	/**
@@ -59,6 +59,6 @@ public final class TestLoggerAdapter implements LoggerAdapter {
 	 * @return the list of messages logged at the specified logging level, or an empty list if none were logged
 	 */
 	public List<String> getMessages(final LoggingLevel level) {
-		return debugMessages.getOrDefault(level, List.of());
+		return messages.getOrDefault(level, List.of());
 	}
 }

--- a/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.morphix.utils.logging;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.morphix.lang.Messages;
+import org.morphix.lang.function.LoggerAdapter;
+
+/**
+ * Test implementation of {@link LoggerAdapter} that captures log messages in memory for verification in tests.
+ *
+ * @author Radu Sebastian LAZIN
+ */
+public final class TestLoggerAdapter implements LoggerAdapter {
+
+	/**
+	 * Map that stores log messages categorized by their logging level. Each logging level maps to a list of messages logged
+	 * at that level.
+	 */
+	private final Map<LoggingLevel, List<String>> debugMessages = new EnumMap<>(LoggingLevel.class);
+
+	/**
+	 * @see LoggerAdapter#log(LoggingLevel, String, Object...)
+	 */
+	@Override
+	public void log(final LoggingLevel level, final String message, final Object... args) {
+		debugMessages.computeIfAbsent(level, k -> new ArrayList<>()).add(Messages.message(message, args));
+	}
+
+	/**
+	 * Returns the map of logged messages categorized by their logging level. Each logging level maps to a list of messages
+	 * logged at that level.
+	 *
+	 * @return the map of logged messages categorized by logging level
+	 */
+	public Map<LoggingLevel, List<String>> getMessages() {
+		return debugMessages;
+	}
+
+	/**
+	 * Returns the list of messages logged at the specified logging level. If no messages were logged at that level, an empty
+	 * list is returned.
+	 *
+	 * @param level the logging level for which to retrieve messages
+	 * @return the list of messages logged at the specified logging level, or an empty list if none were logged
+	 */
+	public List<String> getMessages(final LoggingLevel level) {
+		return debugMessages.getOrDefault(level, List.of());
+	}
+}

--- a/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
+++ b/src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java
@@ -52,8 +52,8 @@ public final class TestLoggerAdapter implements LoggerAdapter {
 	}
 
 	/**
-	 * Returns the list of messages logged at the specified logging level. If no messages were logged at that level, an empty
-	 * list is returned.
+	 * Returns the list of messages logged at the specified logging level. If no messages were logged at that level, an
+	 * empty list is returned.
 	 *
 	 * @param level the logging level for which to retrieve messages
 	 * @return the list of messages logged at the specified logging level, or an empty list if none were logged

--- a/src/test/java/org/morphix/utils/matcher/ContainsAtLeastTimesMatcher.java
+++ b/src/test/java/org/morphix/utils/matcher/ContainsAtLeastTimesMatcher.java
@@ -33,7 +33,7 @@ public class ContainsAtLeastTimesMatcher extends TypeSafeMatcher<String> {
 
 	@Override
 	protected boolean matchesSafely(final String text) {
-		if (text == null || substring == null || substring.isEmpty()) {
+		if (null == text || null == substring || substring.isEmpty()) {
 			return false;
 		}
 

--- a/src/test/resources/test-logging.properties
+++ b/src/test/resources/test-logging.properties
@@ -9,4 +9,4 @@ org.morphix.lang.thread.SelfReschedulingTaskTest.level = FINE
 handlers = java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = FINE
 #java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.ConsoleHandler.formatter = org.morphix.utils.OneLineFormatter
+java.util.logging.ConsoleHandler.formatter = org.morphix.utils.logging.OneLineFormatter

--- a/src/test/resources/test-logging.properties
+++ b/src/test/resources/test-logging.properties
@@ -3,7 +3,7 @@
 
 # Set specific log level
 org.morphix.lang.thread.StackedContextHolder.level = FINE
-org.morphix.lang.thread.SelfReschedulingTaskTest.level = FINE
+org.morphix.lang.thread.ReschedulingTaskTest.level = FINE
 
 # Configure console handler
 handlers = java.util.logging.ConsoleHandler


### PR DESCRIPTION
## Pull request overview

Releases `v1.0.32`, introducing an `ExecutionWrapper` hook for `ReschedulingTask` execution and adding supporting utilities/tests, alongside some logging/test infrastructure updates and widespread null-check style normalization.

**Changes:**
- Add `ExecutionWrapper` support to `ReschedulingTask` and introduce `ExecutionWrappers` helper utilities.
- Improve JUL test logging (formatter package move + throwable handling) and add new tests for wrappers/logging behavior.
- Bump version/release docs to `1.0.32` and normalize null-check style across multiple files.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/test/resources/test-logging.properties | Updates test logging class references (formatter + task test logger level). |
| src/test/java/org/morphix/utils/matcher/ContainsAtLeastTimesMatcher.java | Null-check style normalization in matcher. |
| src/test/java/org/morphix/utils/logging/TestLoggerAdapter.java | New in-memory `LoggerAdapter` for testing wrapper logging. |
| src/test/java/org/morphix/utils/logging/OneLineFormatter.java | Moves formatter into `utils.logging` and adds exception formatting. |
| src/test/java/org/morphix/utils/logging/JulLoggerAdapter.java | Moves adapter into `utils.logging` and adds Throwable-last-arg handling. |
| src/test/java/org/morphix/utils/lang/thread/TenantContextHolder.java | Null-check style normalization. |
| src/test/java/org/morphix/reflection/InstanceCreatorTest.java | Null-check style normalization. |
| src/test/java/org/morphix/lang/thread/ReschedulingTaskTest.java | Adds assertions for execution wrapper defaults + new wrapper/logging tests and tweaks scheduling tests. |
| src/test/java/org/morphix/lang/function/ExecutionWrappersTest.java | New unit tests for `ExecutionWrappers` behaviors. |
| src/test/java/org/morphix/lang/cache/StrictLRUCacheTest.java | Null-check style normalization. |
| src/test/java/org/morphix/lang/cache/ConcurrentStrictLRUCacheTest.java | Null-check style normalization + minor message text tweak. |
| src/test/java/org/morphix/lang/NullablesTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/handler/MapToMapWithExpandableTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/handler/MapToMapTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/handler/IterableToIterableInstancesTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/MapConversionsConvertMapTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/FromIterableTest.java | Null-check style normalization. |
| src/test/java/org/morphix/convert/CloneOfTest.java | Null-check style normalization. |
| src/test/java/org/morphix/benchmark/NullablesOptional.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/jvm/InstanceCreatorOracleJDK.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/Methods.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/MethodType.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/GenericType.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/Fields.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/ExtendedField.java | Null-check style normalization. |
| src/main/java/org/morphix/reflection/Annotations.java | Null-check style normalization. |
| src/main/java/org/morphix/lang/thread/ReschedulingTask.java | Adds `ExecutionWrapper<Void>` support + additional cancellation debug logging. |
| src/main/java/org/morphix/lang/function/PutFunction.java | Null-check style normalization. |
| src/main/java/org/morphix/lang/function/ExecutionWrappers.java | New utility wrappers for logging/timing execution. |
| src/main/java/org/morphix/lang/function/ExecutionWrapper.java | Adds shared `EMPTY` instance and updates `identity()` implementation. |
| src/main/java/org/morphix/lang/Ids.java | Null-check style normalization. |
| src/main/java/org/morphix/convert/strategy/FinderPathStrategy.java | Null-check style normalization. |
| src/main/java/org/morphix/convert/MapConversions.java | Null-check style normalization. |
| pom.xml | Bumps project version to `1.0.32`. |
| README.md | Updates documented current version/dependency snippet to `1.0.32`. |
| CHANGELOG.md | Adds `1.0.32` release notes for new wrapper functionality. |
</details>